### PR TITLE
Add font to front of fallbacks, don't rip out existing sites fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Conditional Font Changer for Google Chrome
+# Improved Font Changer for Google Chrome
 
 ## What is this?
 
@@ -8,7 +8,7 @@ Seren uses an extension to change the fonts on a page to a more readable font, s
 
 One of the main points of contention in her talk was that icon fonts are also changed when she uses the extension, and so in many cases the icons lose their meaning.
 
-I've created this extension to allow the changing of fonts on all elements of a page, while respecting an exclusion list, so that icon fonts (or any other fonts) can remain unchanged.
+I've created this extension to allow the changing of fonts on all elements of a page, while respecting fallback to the existing fonts, so that icon fonts (or any fonts covering code points not included in the replacement font) can remain unchanged.
 
 
 ## Show us the goods!
@@ -29,13 +29,9 @@ Change the font to something else:
 
 ## And the technical details...
 
-The extension saves your "Fonts to exclude" and "Font to use" in `localStorage`, so the fonts you type in these boxes will get saved.
+The extension saves your "Font to use" in `localStorage`, so the font you type in the box will get saved.
 
 When you go to a site that you find hard to read, you simply click the little 'F' icon in the address bar, and then click the 'Change fonts' button.
-
-By default I've provided a couple of common icon font libraries in the "Fonts to exclude", these are:
-
-> "FontAwesome", "Icomoon", "Fontelico", "octicons", "Entypo", "Typicons", "Sitepoint"
 
 If you'd like to install this extension, do the following:
 
@@ -46,6 +42,8 @@ If you'd like to install this extension, do the following:
 
 ## Contributing
 
-I'm open to suggestions of ways to improve this, additional default icon font libraries to exclude, etc.
+Written by http://github.com/rjmunro, and https://github.com/omgmog
+
+I'm open to suggestions of ways to improve this.
 
 If you'd like to contribute, feel free to raise an issue or create a pull request.

--- a/content_script.js
+++ b/content_script.js
@@ -15,7 +15,9 @@ chrome.runtime.onMessage.addListener(
 
           for (var i=0;i<els.length;i++) {
               var oldStyle = window.getComputedStyle(els[i])['font-family'];
-              els[i].style.fontFamily = "'" + newFont + "', " + window.getComputedStyle(els[i])['font-family'];
+              if (oldStyle.indexOf(newFont) === -1) {
+                  els[i].style.fontFamily = "'" + newFont + "', " + window.getComputedStyle(els[i])['font-family'];
+              }
           }
       };
 

--- a/content_script.js
+++ b/content_script.js
@@ -12,7 +12,7 @@ chrome.runtime.onMessage.addListener(
           var els = document.querySelectorAll('body *');
 
           for (var i=0;i<els.length;i++) {
-              var oldStyle = window.getComputedStyle(els[i])['font-family'];
+              var oldStyle = window.getComputedStyle(els[i]).fontFamily;
               if ([0,1].indexOf(oldStyle.indexOf(newFont)) === -1) {
                   // newFont is not the first font, add it
                   els[i].style.fontFamily = "'" + newFont + "', " + window.getComputedStyle(els[i])['font-family'];

--- a/content_script.js
+++ b/content_script.js
@@ -3,9 +3,7 @@
 chrome.runtime.onMessage.addListener(
   function(request, sender, updateIcon) {
     if (request.extensionStorage) {
-      // Here you specify the fonts that you don't want to change, so as not to conflict with icon fonts, etc.
-      var excludedFonts = JSON.parse(request.extensionStorage.excludesList);
-      // Here you specify your new font for everything else
+      // Here you specify your new font
       var newFont = request.extensionStorage.replacementFont;
 
       // Wrap the changer as a function

--- a/content_script.js
+++ b/content_script.js
@@ -14,20 +14,8 @@ chrome.runtime.onMessage.addListener(
           var els = document.querySelectorAll('body *');
 
           for (var i=0;i<els.length;i++) {
-              var elementFonts = window.getComputedStyle(els[i],null).getPropertyValue("font-family").split(',');
-              var changeFont = true;
-              for (var _i=0;_i<elementFonts.length;_i++) {
-                  for (var __i=0;__i<excludedFonts.length;__i++) {
-                      var elementFont = elementFonts[_i].toLowerCase().trim();
-                      var excludeFont = excludedFonts[__i].toLowerCase().trim();
-                      if ( elementFont === excludeFont ) {
-                          changeFont = false;
-                      }
-                  }
-              }
-              if (changeFont) {
-                  els[i].style.fontFamily = newFont;
-              }
+              var oldStyle = window.getComputedStyle(els[i])['font-family'];
+              els[i].style.fontFamily = "'" + newFont + "', " + window.getComputedStyle(els[i])['font-family'];
           }
       };
 

--- a/content_script.js
+++ b/content_script.js
@@ -15,7 +15,8 @@ chrome.runtime.onMessage.addListener(
 
           for (var i=0;i<els.length;i++) {
               var oldStyle = window.getComputedStyle(els[i])['font-family'];
-              if (oldStyle.indexOf(newFont) === -1) {
+              if ([0,1].indexOf(oldStyle.indexOf(newFont)) === -1) {
+                  // newFont is not the first font, add it
                   els[i].style.fontFamily = "'" + newFont + "', " + window.getComputedStyle(els[i])['font-family'];
               }
           }

--- a/content_script.js
+++ b/content_script.js
@@ -9,7 +9,7 @@ chrome.runtime.onMessage.addListener(
       var newFont = request.extensionStorage.replacementFont;
 
       // Wrap the changer as a function
-      var conditionallyChangeFont = function () {
+      var changeFont = function () {
           // Here be dragons. Lots of DOM traversal
           var els = document.querySelectorAll('body *');
 
@@ -35,13 +35,13 @@ chrome.runtime.onMessage.addListener(
       var target = document.querySelectorAll('body')[0];
       var observer = new MutationObserver(function(changes) {
           changes.forEach(function(change) {
-              conditionallyChangeFont();
+              changeFont();
           });
       });
       observer.observe(target, { attributes: true, childList: true});
 
-      // And then call conditionallyChangeFont for good measure
-      conditionallyChangeFont();
+      // And then call changeFont for good measure
+      changeFont();
       updateIcon();
     }
   }

--- a/content_script.js
+++ b/content_script.js
@@ -9,7 +9,7 @@ chrome.runtime.onMessage.addListener(
       // Wrap the changer as a function
       var changeFont = function () {
           // Here be dragons. Lots of DOM traversal
-          var els = document.querySelectorAll('body *');
+          var els = document.querySelectorAll('body,body *');
 
           for (var i=0;i<els.length;i++) {
               var oldStyle = window.getComputedStyle(els[i]).fontFamily;

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
 
-    "name": "Conditional Font Changer for Google Chrome",
-    "description": "Conditionally change fonts on a page, excluding changing certain fonts, e.g. icon fonts.",
+    "name": "Improved Font Changer for Google Chrome",
+    "description": "Change fonts on a page, leaving existing fonts as fallbacks, so that e.g. icon fonts still work.",
     "version": "1.0",
     "content_scripts": [
         {

--- a/popup.html
+++ b/popup.html
@@ -10,12 +10,6 @@
   <form id="form">
     <div>
       <label>
-        Fonts to exclude
-      </label>
-      <input type="text" id="excludesList">
-    </div>
-    <div>
-      <label>
         Font to use
       </label>
       <input type="text" id="replacementFont">

--- a/popup.js
+++ b/popup.js
@@ -1,9 +1,7 @@
 (function () {
   'use strict';
-  var defaultExcludesList = ["FontAwesome", "Icomoon", "Fontelico", "octicons", "Entypo", "Typicons", "Sitepoint"];
   var defaultReplacementFont = "ComicSansMS";
   var optionsForm = document.querySelectorAll('#form')[0];
-  var excludesListInput = document.querySelectorAll('#excludesList')[0];
   var replacementFontInput = document.querySelectorAll('#replacementFont')[0];
 
   var updateFonts = function () {
@@ -26,20 +24,16 @@
   };
 
   var saveOptions = function () {
-    var excludesList = excludesListInput.value.split(/\s*,\s*/) || defaultExcludesList;
     var replacementFont = replacementFontInput.value || defaultReplacementFont;
 
-    localStorage.excludesList = JSON.stringify(excludesList);
     localStorage.replacementFont = replacementFont;
 
     updateFonts();
   };
 
   var loadOptions = function () {
-    var excludesList = JSON.parse(localStorage.excludesList || JSON.stringify(defaultExcludesList));
     var replacementFont = localStorage.replacementFont || defaultReplacementFont;
 
-    excludesListInput.value = excludesList.join(', ');
     replacementFontInput.value = replacementFont;
   };
 


### PR DESCRIPTION
This allows icon fonts to work properly using normal font fallback mechanisms.

It also allows you to specify, e.g. an emoji font, and have all emoji replaced with better emoji, without affecting the text of the site.

It does break the 'ignore' functionality. That could be brought back in, but I don't think it's needed.

Because this removes the main functionality of the extension and replaces it with something different, you might not want to merge this.
